### PR TITLE
Omit .se from the example URL's

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -9,13 +9,13 @@ block content
     h3.example__title Andra exempel
     ul.example__list
       li.example__list-item
-        a(href='/aftonbladet.se').url aftonbladet.se
+        a(href='/aftonbladet').url aftonbladet.se
         |  är upptagen
       li.example__list-item
-        a(href='/extremtledig.se').url extremtledig.se
+        a(href='/extremtledig').url extremtledig.se
         |  är förmodligen ledig
       li.example__list-item
-        a(href='/_",:.se').url _",:.se
+        a(href='/_",:').url _",:.se
         |  är en ogiltig domän
   footer.index-page__about
     h3.about__title Om isfree.se

--- a/views/shared/instructions.jade
+++ b/views/shared/instructions.jade
@@ -1,3 +1,3 @@
-| Besök #[a.url(href='/example.se') isfree.se/example.se] för 
+| Besök #[a.url(href='/example') isfree.se/example] för 
 | att snabbt se om domänen #[span.url-nolink example.se] 
 | är upptagen eller ledig


### PR DESCRIPTION
To make the service easier to use, the examples should not include ".se" in the example URL's. Instead of referring to isfree.se/example.se, we should refer to isfree.se/example.