### PR TITLE
Deploy to production on Cloudflare

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
         uses: cloudflare/wrangler-action@1.2.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
+          environment: 'production'
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ webpack_config = "node_modules/flareact/webpack"
 [env.production]
 name = "isfree-se"
 workers_dev = false
-route = "edge.isfree.se/*"
+route = "isfree.se/*"
 
 [site]
 bucket = "out"


### PR DESCRIPTION
This PR changes the behavior from #9 to deploy to `production` instead of to the development environment on `workers.dev`.

This also changes the deployment target from `https://edge.isfree.se` to `https://isfree.se`.