### PR TITLE
Link to some example domain pages and noindex all other

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,32 +1,28 @@
 module.exports = {
-  "extends": [
-    "airbnb",
-    "plugin:prettier/recommended",
-    "prettier/react"
-  ],
-  "env": {
-    "browser": true,
-    "commonjs": true,
-    "es6": true,
-    "jest": true,
-    "node": true
+  extends: ['airbnb', 'plugin:prettier/recommended', 'prettier/react'],
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true,
+    jest: true,
+    node: true,
   },
-  "rules": {
-    "jsx-a11y/href-no-hash": ["off"],
-    "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
-    "max-len": [
-      "warn",
+  rules: {
+    'jsx-a11y/href-no-hash': ['off'],
+    'react/jsx-filename-extension': ['warn', { extensions: ['.js', '.jsx'] }],
+    'max-len': [
+      'warn',
       {
-        "code": 80,
-        "tabWidth": 2,
-        "comments": 80,
-        "ignoreComments": false,
-        "ignoreTrailingComments": true,
-        "ignoreUrls": true,
-        "ignoreStrings": true,
-        "ignoreTemplateLiterals": true,
-        "ignoreRegExpLiterals": true
-      }
-    ]
-  }
-}
+        code: 80,
+        tabWidth: 2,
+        comments: 80,
+        ignoreComments: false,
+        ignoreTrailingComments: true,
+        ignoreUrls: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+        ignoreRegExpLiterals: true,
+      },
+    ],
+  },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   rules: {
     'jsx-a11y/href-no-hash': ['off'],
+    'react/react-in-jsx-scope': ['off'],
     'react/jsx-filename-extension': ['warn', { extensions: ['.js', '.jsx'] }],
     'max-len': [
       'warn',

--- a/components/Instructions.jsx
+++ b/components/Instructions.jsx
@@ -1,8 +1,7 @@
 const Instructions = () => (
   <>
-    Besök <a href="/example.se">isfree.se/example</a> för att snabbt se om
-    domänen <span className="url-nolink">example.se</span> är upptagen eller
-    ledig
+    Besök <a href="/example">isfree.se/example</a> för att snabbt se om domänen{' '}
+    <span className="url-nolink">example.se</span> är upptagen eller ledig
   </>
 );
 

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -2,12 +2,14 @@ import Head from 'flareact/head';
 
 const Layout = ({
   pageTitleSuffix = 'Kolla snabbt om en svensk .se-domän är ledig!',
+  noindex = false,
   children,
 }) => (
   <>
     <div className="content">
       <Head>
         <title>{`isfree.se | ${pageTitleSuffix}`}</title>
+        {noindex && <meta name="robots" content="noindex, follow" />}
         <script>
           {`
             window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,10 +1,7 @@
 import Head from 'flareact/head';
+import PropTypes from 'prop-types';
 
-const Layout = ({
-  pageTitleSuffix = 'Kolla snabbt om en svensk .se-domän är ledig!',
-  noindex = false,
-  children,
-}) => (
+const Layout = ({ pageTitleSuffix, noindex, children }) => (
   <>
     <div className="content">
       <Head>
@@ -26,5 +23,16 @@ const Layout = ({
     </div>
   </>
 );
+
+Layout.defaultProps = {
+  pageTitleSuffix: 'Kolla snabbt om en svensk .se-domän är ledig!',
+  noindex: false,
+};
+
+Layout.propTypes = {
+  pageTitleSuffix: PropTypes.string,
+  noindex: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
 
 export default Layout;

--- a/components/Result.jsx
+++ b/components/Result.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 const Result = ({ domainTld, status }) => {
   if (status === 'FREE') {
     return (
@@ -21,6 +23,11 @@ const Result = ({ domainTld, status }) => {
       domännamn!
     </>
   );
+};
+
+Result.propTypes = {
+  domainTld: PropTypes.string.isRequired,
+  status: PropTypes.oneOf(['FREE', 'OCCUPIED', 'NOT_VALID']).isRequired,
 };
 
 export default Result;

--- a/components/ResultDescription.jsx
+++ b/components/ResultDescription.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 const description = {
   FREE: 'Den här domänen går att registrera',
   OCCUPIED: 'Den här domänen har redan registrerats',
@@ -5,5 +7,9 @@ const description = {
 };
 
 const ResultDescription = ({ status }) => <>{description[status]}</>;
+
+ResultDescription.propTypes = {
+  status: PropTypes.oneOf(Object.keys(description)).isRequired,
+};
 
 export default ResultDescription;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "flareact": "^1.1.1-canary.1",
+    "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "se-free": "1.0.5"

--- a/pages/[domain].se.js
+++ b/pages/[domain].se.js
@@ -1,4 +1,5 @@
 import seFree from 'se-free';
+import PropTypes from 'prop-types';
 
 import Layout from '../components/Layout';
 import Instructions from '../components/Instructions';
@@ -40,5 +41,11 @@ const DomainDotSePage = ({ domainTld, status, noindex }) => (
     </footer>
   </Layout>
 );
+
+DomainDotSePage.propTypes = {
+  domainTld: PropTypes.string.isRequired,
+  status: PropTypes.oneOf(['FREE', 'OCCUPIED', 'NOT_VALID']).isRequired,
+  noindex: PropTypes.bool.isRequired,
+};
 
 export default DomainDotSePage;

--- a/pages/[domain].se.js
+++ b/pages/[domain].se.js
@@ -5,23 +5,27 @@ import Instructions from '../components/Instructions';
 import Result from '../components/Result';
 import ResultDescription from '../components/ResultDescription';
 
+const allowIndexing = ['example.se', 'isfree.se', 'ledig-doman.se', '🦄.se'];
+
 export async function getEdgeProps({ params }) {
   const { domain } = params;
   const uriDecodedDomain = decodeURI(domain);
   const domainTld = `${uriDecodedDomain}.se`;
+  const noindex = !allowIndexing.includes(domainTld);
   const status = await seFree(domainTld);
 
   return {
     props: {
       domainTld,
       status,
+      noindex,
     },
     revalidate: 60, // Revalidate these props once every 60 seconds
   };
 }
 
-const DomainDotSePage = ({ domainTld, status }) => (
-  <Layout pageTitleSuffix={`Är domänen ${domainTld} ledig?`}>
+const DomainDotSePage = ({ domainTld, status, noindex }) => (
+  <Layout pageTitleSuffix={`Är domänen ${domainTld} ledig?`} noindex={noindex}>
     <header>
       <h1 className="title">
         <Result domainTld={domainTld} status={status} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,20 +14,20 @@ export default function Index() {
         <h3 className="example__title">Andra exempel</h3>
         <ul className="example__list">
           <li className="example__list-item">
-            <a href="/aftonbladet.se" className="url">
-              aftonbladet.se
+            <a href="/isfree" className="url">
+              isfree.se
             </a>{' '}
             är upptagen
           </li>
           <li className="example__list-item">
-            <a href="/extremtledig.se" className="url">
-              extremtledig.se
+            <a href="/ledig-doman" className="url">
+              ledig-doman.se
             </a>{' '}
             är förmodligen ledig
           </li>
           <li className="example__list-item">
-            <a href="/_,:.se" className="url">
-              _,:.se
+            <a href="/🦄" className="url">
+              🦄.se
             </a>{' '}
             är en ogiltig domän
           </li>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url>
+  <loc>https://isfree.se/</loc>
+</url>
+<url>
+  <loc>https://isfree.se/example.se</loc>
+</url>
+<url>
+  <loc>https://isfree.se/isfree.se</loc>
+</url>
+<url>
+  <loc>https://isfree.se/ledig-doman.se</loc>
+</url>
+<url>
+  <loc>https://isfree.se/🦄.se</loc>
+</url>
+</urlset>


### PR DESCRIPTION
This PR adds a list of domain pages that is allowed to be indexed, and adds a `noindex` tag to all other.

The allowed pages are:
- `example.se`
- `isfree.se`
- `ledig-doman.se`
- `🦄.se`

This PR also changes the examples on the start page to match this list, and adds a `sitemap.xml` listing them together with the start page.

Additionally, the ESLint configuration is updated to ignore _React not in scope_ (unnecessary when using Flareact) and [PropTypes](https://www.npmjs.com/package/prop-types) validation is added. 
