### PR TITLE
Display updated at timestamp on domain page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "flareact": "^1.1.1-canary.1",
+    "luxon": "^1.26.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/pages/[domain].se.js
+++ b/pages/[domain].se.js
@@ -1,5 +1,6 @@
 import seFree from 'se-free';
 import PropTypes from 'prop-types';
+import { DateTime } from 'luxon';
 
 import Layout from '../components/Layout';
 import Instructions from '../components/Instructions';
@@ -14,18 +15,22 @@ export async function getEdgeProps({ params }) {
   const domainTld = `${uriDecodedDomain}.se`;
   const noindex = !allowIndexing.includes(domainTld);
   const status = await seFree(domainTld);
+  const updatedAt = DateTime.now()
+    .setZone('Europe/Stockholm')
+    .toFormat('yyyy-LL-dd T');
 
   return {
     props: {
       domainTld,
       status,
       noindex,
+      updatedAt,
     },
     revalidate: 60, // Revalidate these props once every 60 seconds
   };
 }
 
-const DomainDotSePage = ({ domainTld, status, noindex }) => (
+const DomainDotSePage = ({ domainTld, status, noindex, updatedAt }) => (
   <Layout pageTitleSuffix={`Är domänen ${domainTld} ledig?`} noindex={noindex}>
     <header>
       <h1 className="title">
@@ -38,6 +43,7 @@ const DomainDotSePage = ({ domainTld, status, noindex }) => (
     <footer className="result-page__usage">
       <h3 className="usage__title">Hur använder jag isfree.se?</h3>
       <Instructions />
+      <div className="updated-at">Informationen uppdaterades {updatedAt}</div>
     </footer>
   </Layout>
 );
@@ -46,6 +52,7 @@ DomainDotSePage.propTypes = {
   domainTld: PropTypes.string.isRequired,
   status: PropTypes.oneOf(['FREE', 'OCCUPIED', 'NOT_VALID']).isRequired,
   noindex: PropTypes.bool.isRequired,
+  updatedAt: PropTypes.string.isRequired,
 };
 
 export default DomainDotSePage;

--- a/styles/style.css
+++ b/styles/style.css
@@ -81,3 +81,8 @@ a {
    -webkit-hyphens: auto;
    hyphens: auto;
 }
+
+.updated-at {
+  padding-top: 1rem;
+  font-size: 0.8rem;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4552,6 +4552,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^1.26.0:
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.26.0.tgz#d3692361fda51473948252061d0f8561df02b578"
+  integrity sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==
+
 make-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
This PR adds a last updated at timestamp on the domain page using [Luxon](https://moment.github.io/luxon/index.html). This is intended to improve trust that the information is not stale.

The string is cached along with the rest of the page for 60 seconds, and is passed as a formatted string. The date format is Swedish `yyyy-LL-dd T` which means something like "2021-01-01 13:37".

![Screenshot](https://user-images.githubusercontent.com/4640371/108894935-3cb6c800-7613-11eb-8a40-f03d324d2677.png)
