### PR TITLE
Link to whois for occupied domains

### DIFF
--- a/components/ResultWhois.jsx
+++ b/components/ResultWhois.jsx
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+const ResultWhois = ({ status, domainTld }) =>
+  status === 'OCCUPIED' && (
+    <a href={`https://internetstiftelsen.se/sok-doman/?domain=${domainTld}`}>
+      Se vem som registrerat {domainTld}
+    </a>
+  );
+
+ResultWhois.propTypes = {
+  status: PropTypes.oneOf(['FREE', 'OCCUPIED', 'NOT_VALID']).isRequired,
+  domainTld: PropTypes.string.isRequired,
+};
+
+export default ResultWhois;

--- a/components/ResultWhois.jsx
+++ b/components/ResultWhois.jsx
@@ -2,7 +2,11 @@ import PropTypes from 'prop-types';
 
 const ResultWhois = ({ status, domainTld }) =>
   status === 'OCCUPIED' && (
-    <a href={`https://internetstiftelsen.se/sok-doman/?domain=${domainTld}`}>
+    <a
+      href={`https://internetstiftelsen.se/sok-doman/?domain=${encodeURIComponent(
+        domainTld
+      )}`}
+    >
       Se vem som registrerat {domainTld}
     </a>
   );

--- a/pages/[domain].se.js
+++ b/pages/[domain].se.js
@@ -6,6 +6,7 @@ import Layout from '../components/Layout';
 import Instructions from '../components/Instructions';
 import Result from '../components/Result';
 import ResultDescription from '../components/ResultDescription';
+import ResultWhois from '../components/ResultWhois';
 
 const allowIndexing = ['example.se', 'isfree.se', 'ledig-doman.se', '🦄.se'];
 
@@ -39,6 +40,7 @@ const DomainDotSePage = ({ domainTld, status, noindex, updatedAt }) => (
       <h2 className="result-page__description">
         <ResultDescription status={status} />
       </h2>
+      <ResultWhois status={status} domainTld={domainTld} />
     </header>
     <footer className="result-page__usage">
       <h3 className="usage__title">Hur använder jag isfree.se?</h3>


### PR DESCRIPTION
This PR adds an external link to the official whois information for all occupied (registered) domains.

The link is `https://internetstiftelsen.se/sok-doman/?domain={domain}`.

## Screenshots
![Whois link](https://user-images.githubusercontent.com/4640371/109060271-7f48d500-76e5-11eb-9560-daeb937cd023.png)

_Whois information on the linked page_
![Whois information](https://user-images.githubusercontent.com/4640371/109060406-aacbbf80-76e5-11eb-878d-19e9e2694b58.png)
