### PR TITLE
Handle UTS 46 error in se-free

### DIFF
--- a/pages/[domain].se.js
+++ b/pages/[domain].se.js
@@ -10,12 +10,16 @@ import ResultWhois from '../components/ResultWhois';
 
 const allowIndexing = ['example.se', 'isfree.se', 'ledig-doman.se', '🦄.se'];
 
+const checkDomainStatus = async (domainTld) => {
+  return seFree(domainTld);
+};
+
 export async function getEdgeProps({ params }) {
   const { domain } = params;
   const uriDecodedDomain = decodeURI(domain);
   const domainTld = `${uriDecodedDomain}.se`;
   const noindex = !allowIndexing.includes(domainTld);
-  const status = await seFree(domainTld);
+  const status = await checkDomainStatus(domainTld);
   const updatedAt = DateTime.now()
     .setZone('Europe/Stockholm')
     .toFormat('yyyy-LL-dd T');

--- a/pages/[domain].se.js
+++ b/pages/[domain].se.js
@@ -11,7 +11,11 @@ import ResultWhois from '../components/ResultWhois';
 const allowIndexing = ['example.se', 'isfree.se', 'ledig-doman.se', '🦄.se'];
 
 const checkDomainStatus = async (domainTld) => {
-  return seFree(domainTld);
+  try {
+    return seFree(domainTld);
+  } catch (error) {
+    return 'NOT_VALID';
+  }
 };
 
 export async function getEdgeProps({ params }) {


### PR DESCRIPTION
This PR adds fallback error handling around [`se-free`](https://www.npmjs.com/package/se-free), which does not correctly handle all internal errors.

In particular, `idna-uts46` may raise an error when the domain name [does not conform to the UTS #46 rules](https://unicode.org/reports/tr46/#Validity_Criteria). An excerpt from the validity criteria:

>the label must neither begin nor end with a U+002D HYPHEN-MINUS character.

which means that the domain `-example.se` is not valid.

This would previously cause an unhandled error, while this PR will not correctly identify it as an invalid domain name.